### PR TITLE
Prepaid card at example

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -31,6 +31,7 @@ async function loadPaymentForm() {
             paymentMethods: {
                 creditCard: 'all',
                 debitCard: 'all',
+                prepaidCard: 'all',
                 /*
                     If some of the following payment methods is not valid for your country,
                     the Brick will show a warning message in the browser console


### PR DESCRIPTION
This PR intents to add prepaid card as a payment type at Payment Brick Example